### PR TITLE
Debug server log errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,10 +13,12 @@
 		"format": "prettier --write .",
 		"lint": "prettier --check . && eslint ."
 	},
+	"dependencies": {
+		"@nhost/nhost-js": "^4.1.0"
+	},
 	"devDependencies": {
 		"@eslint/compat": "^1.4.1",
 		"@eslint/js": "^9.39.1",
-		"@nhost/nhost-js": "^4.1.0",
 		"@sveltejs/adapter-vercel": "^6.1.1",
 		"@sveltejs/kit": "^2.48.4",
 		"@sveltejs/vite-plugin-svelte": "^6.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,10 @@ settings:
 importers:
 
   .:
+    dependencies:
+      '@nhost/nhost-js':
+        specifier: ^4.1.0
+        version: 4.1.0
     devDependencies:
       '@eslint/compat':
         specifier: ^1.4.1
@@ -14,9 +18,6 @@ importers:
       '@eslint/js':
         specifier: ^9.39.1
         version: 9.39.1
-      '@nhost/nhost-js':
-        specifier: ^4.1.0
-        version: 4.1.0
       '@sveltejs/adapter-vercel':
         specifier: ^6.1.1
         version: 6.1.1(@sveltejs/kit@2.48.4(@sveltejs/vite-plugin-svelte@6.2.1(svelte@5.43.3)(vite@7.1.12(terser@5.44.0)))(svelte@5.43.3)(vite@7.1.12(terser@5.44.0)))(rollup@2.79.2)

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,6 +3,9 @@ import { VitePWA } from 'vite-plugin-pwa';
 
 /** @type {import('vite').UserConfig} */
 const config = {
+  ssr: {
+    noExternal: ['@nhost/nhost-js']
+  },
   plugins: [
     sveltekit(),
     VitePWA({


### PR DESCRIPTION
Fixes the server-side runtime error:
SyntaxError: Named export 'createClient' not found

Changes:
- Move @nhost/nhost-js from devDependencies to dependencies (needed at runtime on the server)
- Add ssr.noExternal config to vite.config.ts to bundle @nhost/nhost-js for SSR, handling CommonJS to ESM conversion

This resolves the 500 errors on all routes caused by module import failures in the Node.js ESM runtime.